### PR TITLE
Auto-inherit extraction pointer on SillyTavern checkpoint/branch 

### DIFF
--- a/index.js
+++ b/index.js
@@ -3231,6 +3231,13 @@ async function onChatChanged() {
     const chatId = context.chatId || '(none)';
     const charName = getCharacterName() || '(none)';
     const msgCount = context.chat ? context.chat.length : 0;
+    // Used below to re-validate before writes that follow a real await (fetchChatMessages
+    // and readMemoriesForCharacter are both network round trips) — the user can switch
+    // chats again while this invocation is still running, and a write after that point
+    // would target the wrong chat's metadata object.
+    const savedChatId = context.chatId;
+    const savedGroupId = context.groupId;
+    const stillSameChat = () => getContext().chatId === savedChatId && getContext().groupId === savedGroupId;
 
     logActivity(`Chat changed: "${charName}" chat=${chatId} (${msgCount} messages)`);
 
@@ -3263,7 +3270,7 @@ async function onChatChanged() {
         try {
             const parent = await fetchChatMessages(chat_metadata.main_chat);
             const parentLastIdx = parent?.metadata?.[MODULE_NAME]?.lastExtractedIndex;
-            if (typeof parentLastIdx === 'number' && parentLastIdx >= 0) {
+            if (typeof parentLastIdx === 'number' && parentLastIdx >= 0 && stillSameChat()) {
                 const inherited = Math.min(parentLastIdx, msgCount - 1);
                 if (inherited >= 0) {
                     meta.lastExtractedIndex = inherited;
@@ -3311,7 +3318,11 @@ async function onChatChanged() {
                         break;
                     }
                 }
-                if (!hasAnyMemories) {
+                if (hasAnyMemories) {
+                    // no reset needed
+                } else if (!stillSameChat()) {
+                    logActivity('Skipped stale-metadata reset — chat changed while checking memory files', 'warning');
+                } else {
                     meta.lastExtractedIndex = -1;
                     saveMetadataDebounced();
                     logActivity(`Auto-reset lastExtractedIndex: was ${lastIdx} but memory file is empty — stale metadata`, 'warning');

--- a/index.js
+++ b/index.js
@@ -3249,6 +3249,33 @@ async function onChatChanged() {
     const meta = chat_metadata[MODULE_NAME];
     const lastIdx = meta.lastExtractedIndex ?? -1;
 
+    // If this chat has no extraction history yet, check whether it's a SillyTavern
+    // checkpoint/branch of another chat. ST does not copy chat_metadata into a new
+    // checkpoint — it builds a fresh { main_chat: <parent chat id> } object — so
+    // lastExtractedIndex always starts at -1 on a checkpoint even though the copied
+    // messages already had memories extracted from them in the parent. Previously
+    // this silently forced a full re-extraction unless the user manually clicked
+    // "Mark as Fully Extracted". Auto-inherit the parent's pointer instead, clamped
+    // to this chat's own length in case the checkpoint was made at an earlier point
+    // in the parent's history. Scoped to 1:1 chats — fetchChatMessages() reads via
+    // this_chid/character avatar and doesn't resolve group checkpoint files.
+    if (lastIdx === -1 && chat_metadata.main_chat && !isGroupChat() && msgCount > 0) {
+        try {
+            const parent = await fetchChatMessages(chat_metadata.main_chat);
+            const parentLastIdx = parent?.metadata?.[MODULE_NAME]?.lastExtractedIndex;
+            if (typeof parentLastIdx === 'number' && parentLastIdx >= 0) {
+                const inherited = Math.min(parentLastIdx, msgCount - 1);
+                if (inherited >= 0) {
+                    meta.lastExtractedIndex = inherited;
+                    saveMetadataDebounced();
+                    logActivity(`Inherited extraction pointer ${inherited} from parent chat "${chat_metadata.main_chat}" (checkpoint/branch) — existing messages won't be re-extracted.`, 'success');
+                }
+            }
+        } catch (err) {
+            console.error(LOG_PREFIX, 'Failed to inherit extraction pointer from parent chat:', err);
+        }
+    }
+
     // Detect stale metadata: lastExtractedIndex is set but the memory file is empty.
     // This happens when old code advanced the index even on NO_NEW_MEMORIES, or when
     // the user clears memories after extraction. Auto-reset so extraction can run.


### PR DESCRIPTION
## Summary

SillyTavern does not copy `chat_metadata` into a new checkpoint/branch chat — it builds a fresh `{ main_chat: <parent chat id> }` object instead (confirmed by reading ST core's `bookmarks.js`, `createNewBookmark`). So `lastExtractedIndex` always started at -1 on a checkpoint even though the copied messages already had memories extracted from them in the parent chat, silently forcing a full re-extraction unless the user manually clicked "Mark as Fully Extracted."

On `CHAT_CHANGED`, if the current chat has no extraction history yet and its metadata carries a `main_chat` pointer, this fetches the parent chat's `lastExtractedIndex` (`fetchChatMessages()` already existed for batch extraction and works here unchanged) and inherits it, clamped to the current chat's own message count in case the checkpoint was made earlier in the parent's history than its current extraction progress. Also guarded against a chat-switch race while the inherit fetch is in flight (same class of fix as the reentrancy-races PR).

Scoped to 1:1 chats — `fetchChatMessages()` reads via `this_chid`/character avatar and doesn't resolve group checkpoint files, so group chats are unaffected (same scoping precedent as the hide-extracted-messages feature).

## Now Verified

## Testing

Syntax-checked, full unit suite passing (178/178). No live checkpoint test performed (see above).

## Notes

Full audit trail: https://github.com/Echo-Storm/sillytavern-character-memory/blob/tools/tools/PROJECT-NOTES.md