### PR TITLE
Fix drawer state-persistence bug, touch resize/swipe conflict, wizard reentrancy

### DIFF
--- a/index.js
+++ b/index.js
@@ -5251,12 +5251,31 @@ function updateModalProviderUI() {
 
 // ============ Setup Wizard ============
 
+// Reentrancy guard for showSetupWizard — it has no equivalent of extraction/consolidation/
+// reformat's inApiCall-style locks, but it's reachable from three independent triggers
+// (first-launch auto-open, the dashboard "Open Wizard" button, the Settings modal's "Run
+// Setup Wizard" link) plus two setTimeout-deferred re-opens. Internal step navigation
+// (Next/Back) doesn't recurse back into showSetupWizard - it's handled by show/hide within
+// one popup instance - so a simple claim-at-entry/release-at-exit guard is safe here and
+// doesn't interfere with a wizard already in progress moving between its own steps.
+let wizardOpen = false;
+
 /**
  * Build and display the 3-step Setup Wizard modal.
  * Steps: 1) LLM Connection  2) Vector Storage  3) Ready
  * @param {number} [startStep=1] Step to start on (1, 2, or 3)
  */
 async function showSetupWizard(startStep = 1) {
+    if (wizardOpen) return;
+    wizardOpen = true;
+    try {
+        return await showSetupWizardInner(startStep);
+    } finally {
+        wizardOpen = false;
+    }
+}
+
+async function showSetupWizardInner(startStep = 1) {
     const s = extension_settings[MODULE_NAME];
     const providerKey = s.selectedProvider || '';
     const providerSettings = providerKey ? getProviderSettings(providerKey) : {};
@@ -8772,6 +8791,12 @@ function toggleLogDrawer(forceState) {
     if (shouldOpen) {
         $('#charMemory_injectionDrawer').removeClass('open');
         $('#charMemory_drawerToggle').removeClass('open');
+        // Mirror toggleInjectionDrawer(false)'s persistence — closing it here via raw DOM
+        // manipulation without also clearing injectionDrawerOpen left the flag stale, so
+        // the injection drawer would incorrectly auto-reopen on the next page load even
+        // though the user's last visible action was opening the log drawer instead.
+        extension_settings[MODULE_NAME].injectionDrawerOpen = false;
+        saveSettingsDebounced();
     }
 
     // Position drawer below ST's top bar so header isn't clipped by browser chrome
@@ -9611,10 +9636,19 @@ jQuery(async function () {
     const logDrawerEl = document.getElementById('charMemory_logDrawer');
     if (logDrawerEl) {
         let logTouchStartX = 0;
+        let logTouchFromHandle = false;
         logDrawerEl.addEventListener('touchstart', (e) => {
+            // The drag-to-resize handle is a child of this same drawer element and has
+            // its own pointerdown/pointermove/pointerup handlers (setupDrawerResize) —
+            // those don't suppress this touchstart/touchend pair, since pointer capture
+            // doesn't stop native touch events from also bubbling up from the handle.
+            // Without this check, resizing the drawer via touch could simultaneously
+            // satisfy the swipe-to-close distance and close the drawer being resized.
+            logTouchFromHandle = !!e.target.closest('.charMemory_drawerResizeHandle');
             logTouchStartX = e.touches[0].clientX;
         }, { passive: true });
         logDrawerEl.addEventListener('touchend', (e) => {
+            if (logTouchFromHandle) return;
             const deltaX = e.changedTouches[0].clientX - logTouchStartX;
             if (deltaX > 60) toggleLogDrawer(false);
         }, { passive: true });
@@ -9694,12 +9728,17 @@ jQuery(async function () {
 
     // Swipe right to close drawer (touch devices)
     let touchStartX = 0;
+    let touchFromHandle = false;
     const drawer = document.getElementById('charMemory_injectionDrawer');
     if (drawer) {
         drawer.addEventListener('touchstart', (e) => {
+            // See the identical comment on the log drawer's touchstart handler — the
+            // resize handle's touch events bubble up to this drawer-level listener too.
+            touchFromHandle = !!e.target.closest('.charMemory_drawerResizeHandle');
             touchStartX = e.touches[0].clientX;
         }, { passive: true });
         drawer.addEventListener('touchend', (e) => {
+            if (touchFromHandle) return;
             const deltaX = e.changedTouches[0].clientX - touchStartX;
             if (deltaX > 60) toggleInjectionDrawer(false);
         }, { passive: true });


### PR DESCRIPTION
## Summary

Three unrelated pre-existing bugs, found by a follow-up sweep that specifically targeted areas not covered by the first pass (mobile/touch, Setup Wizard, drawer resize/positioning).

- **Drawer state-persistence bug**: `toggleLogDrawer()` force-closes the injection drawer via raw DOM class removal instead of calling `toggleInjectionDrawer(false)`, so it never clears the persisted `injectionDrawerOpen` setting. Open the injection drawer, then open the log drawer (which closes the injection drawer as a side effect, same screen position) — `injectionDrawerOpen` stays `true`, so on the next page load the injection drawer incorrectly auto-reopens even though the user's last visible action was opening the log drawer instead.
- **Touch resize-vs-swipe-close conflict**: the drag-to-resize handle (`pointerdown`/`pointermove`/`pointerup` with `setPointerCapture`) lives inside the same drawer element that has `touchstart`/`touchend` listeners for swipe-to-close. Pointer capture doesn't suppress native touch events from also bubbling up from the handle, so on a touch device, dragging the resize handle can simultaneously satisfy the swipe-to-close distance threshold and close the drawer being resized. Both drawers' touch listeners now check whether the touch originated on the resize handle and skip swipe-to-close if so.
- **Setup Wizard reentrancy**: `showSetupWizard()` had no guard, unlike comparable async flows in this codebase (extraction/consolidation/reformat all use `inApiCall`/`*InFlight`-style locks). It's reachable from three independent triggers (first-launch auto-open, dashboard "Open Wizard" button, Settings modal's "Run Setup Wizard" link) plus two `setTimeout`-deferred re-opens — a fast double-trigger could create two simultaneous wizard popups. Added a guard via the same thin-wrapper pattern used elsewhere; confirmed internal step (Next/Back) navigation doesn't recurse back into `showSetupWizard` itself, so the guard can't deadlock a wizard already in progress.

## Testing

Syntax-checked, full unit suite passing (178/178). Didn't have a touch device handy to reproduce the resize/swipe conflict physically — traced it through the actual event-listener code (confirmed both the resize handle's pointer events and the drawer's touch events are both live on the same element with no propagation guard between them). The wizard reentrancy gap and the drawer-close persistence bug were both confirmed by direct code read against the actual control flow.

## Notes

Found by the same audit pass as #22-#28: https://github.com/bal-spec/sillytavern-character-memory/pull/22#issuecomment-5085703567 has the full index. Notes: https://github.com/Echo-Storm/sillytavern-character-memory/blob/tools/tools/PROJECT-NOTES.md